### PR TITLE
Use jwt.verify helper in API routes

### DIFF
--- a/src/app/api/cartes/[id]/route.ts
+++ b/src/app/api/cartes/[id]/route.ts
@@ -2,13 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/utils/auth'
 
 async function getUserIdFromRequest() {
   const cookieStore = await cookies()
   const token = cookieStore.get('payload-token')?.value
-  if (!token) return null
-  const decoded = jwt.decode(token)
+  const decoded = getUserFromToken(token)
   if (!decoded || typeof decoded !== 'object' || !decoded.id) return null
   return decoded.id
 }

--- a/src/app/api/cartes/route.ts
+++ b/src/app/api/cartes/route.ts
@@ -2,13 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/utils/auth'
 
 async function getUserIdFromRequest() {
   const cookieStore = await cookies()
   const token = cookieStore.get('payload-token')?.value
-  if (!token) return null
-  const decoded = jwt.decode(token)
+  const decoded = getUserFromToken(token)
   if (!decoded || typeof decoded !== 'object' || !decoded.id) return null
   return decoded.id
 }

--- a/src/app/api/custom-cat/route.ts
+++ b/src/app/api/custom-cat/route.ts
@@ -2,13 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/utils/auth'
 
 async function getUserIdFromRequest() {
   const cookieStore = await cookies()
   const token = cookieStore.get('payload-token')?.value
-  if (!token) return null
-  const decoded = jwt.decode(token)
+  const decoded = getUserFromToken(token)
   if (!decoded || typeof decoded !== 'object' || !decoded.id) return null
   return decoded.id
 }

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/utils/auth'
 
 export async function GET(req: NextRequest) {
   const cookieStore = await cookies()
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const decoded = jwt.decode(token)
+    const decoded = getUserFromToken(token)
     if (!decoded || typeof decoded !== 'object' || !decoded.id) {
       return NextResponse.json({ user: null }, { status: 401 })
     }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken'
+
+export interface DecodedUser {
+  id?: string
+  email?: string
+  [key: string]: any
+}
+
+export function getUserFromToken(token?: string | null): DecodedUser | null {
+  if (!token) return null
+  try {
+    const decoded = jwt.verify(token, process.env.PAYLOAD_SECRET as string)
+    if (typeof decoded === 'object') {
+      return decoded as DecodedUser
+    }
+  } catch (err) {
+    console.error('[auth] Invalid token', err)
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- add `getUserFromToken` helper
- verify tokens in `me`, `cartes`, and `custom-cat` APIs

## Testing
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_b_683b290392108326a6d7ccb929050205