### PR TITLE
Limit access to user documents

### DIFF
--- a/src/collections/Cartes.ts
+++ b/src/collections/Cartes.ts
@@ -6,10 +6,10 @@ const Cartes: CollectionConfig = {
     useAsTitle: 'titre',
   },
   access: {
-    read: ({ req }) => !!req.user,
+    read: ({ req, data }) => req.user?.id === data.user,
     create: ({ req }) => !!req.user,
-    update: ({ req }) => !!req.user,
-    delete: ({ req }) => !!req.user,
+    update: ({ req, data }) => req.user?.id === data.user,
+    delete: ({ req, data }) => req.user?.id === data.user,
   },
   fields: [
     {

--- a/src/collections/CustomCat.ts
+++ b/src/collections/CustomCat.ts
@@ -6,10 +6,10 @@ const CustomCat: CollectionConfig = {
     useAsTitle: 'nom',
   },
   access: {
-    read: ({ req }) => !!req.user,
+    read: ({ req, data }) => req.user?.id === data.user,
     create: ({ req }) => !!req.user,
-    update: ({ req }) => !!req.user,
-    delete: ({ req }) => !!req.user,
+    update: ({ req, data }) => req.user?.id === data.user,
+    delete: ({ req, data }) => req.user?.id === data.user,
   },
   fields: [
     {

--- a/src/collections/Notes.ts
+++ b/src/collections/Notes.ts
@@ -6,10 +6,10 @@ const Notes: CollectionConfig = {
     useAsTitle: 'titre',
   },
   access: {
-    read: ({ req }) => !!req.user,
+    read: ({ req, data }) => req.user?.id === data.user,
     create: ({ req }) => !!req.user,
-    update: ({ req }) => !!req.user,
-    delete: ({ req }) => !!req.user,
+    update: ({ req, data }) => req.user?.id === data.user,
+    delete: ({ req, data }) => req.user?.id === data.user,
   },
   fields: [
     {


### PR DESCRIPTION
## Summary
- limit `read`, `update` and `delete` access to only the document owner in Notes, Cartes and CustomCat collections

## Testing
- `pnpm lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b2905363883269b2a2c34b054ba82