### PR TITLE
Ajout du workflow CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: true
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+


### PR DESCRIPTION
## Notes
- Ajout d'un workflow GitHub Actions (`.github/workflows/ci.yml`) qui installe les dépendances avec `pnpm`, puis exécute `pnpm lint` et `pnpm build`.
- La pipeline échouera si l'une des commandes retourne un code de sortie non nul.

## Résultats des tests
- `pnpm lint` et `pnpm build` échouent localement car les dépendances ne sont pas installées.


------
https://chatgpt.com/codex/tasks/task_b_683b29077f44832692191010142a52f6