### PR TITLE
Refactor dashboard auth handling

### DIFF
--- a/src/app/(frontend)/dashboard/layout.tsx
+++ b/src/app/(frontend)/dashboard/layout.tsx
@@ -1,24 +1,12 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { getPayload } from 'payload'
-import config from '@/payload.config'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/utils/auth'
 import ClientLayout from './ClientLayout'
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies()
   const token = cookieStore.get('payload-token')?.value
-  let user = null
-  if (token) {
-    try {
-      const decoded = jwt.decode(token)
-      if (decoded && typeof decoded === 'object' && decoded.email) {
-        user = decoded
-      }
-    } catch {
-      user = null
-    }
-  }
+  const user = getUserFromToken(token)
   if (!user) {
     redirect('/login')
   }


### PR DESCRIPTION
## Summary
- use `getUserFromToken` in dashboard layout
- redirect to login if token invalid

## Testing
- `pnpm lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b340aa9e88326b083db2b70a818a2