### PR TITLE
Fix Node version mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   payload:
-    image: node:18-alpine
+    image: node:22.12.0-alpine
     ports:
       - '3000:3000'
     volumes:


### PR DESCRIPTION
## Summary
- align `docker-compose.yml` with the Dockerfile by using the same Node base image

## Testing
- `pnpm lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bf08c879c8326a859e5df2770fc8b