### PR TITLE
Add JWT verify helper

### DIFF
--- a/src/app/(frontend)/dashboard/layout.tsx
+++ b/src/app/(frontend)/dashboard/layout.tsx
@@ -1,8 +1,6 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { getPayload } from 'payload'
-import config from '@/payload.config'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/lib/auth'
 import ClientLayout from './ClientLayout'
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -11,7 +9,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
   let user = null
   if (token) {
     try {
-      const decoded = jwt.decode(token)
+      const decoded = getUserFromToken(token)
       if (decoded && typeof decoded === 'object' && decoded.email) {
         user = decoded
       }

--- a/src/app/api/cartes/[id]/route.ts
+++ b/src/app/api/cartes/[id]/route.ts
@@ -2,15 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/lib/auth'
 
 async function getUserIdFromRequest() {
   const cookieStore = await cookies()
   const token = cookieStore.get('payload-token')?.value
   if (!token) return null
-  const decoded = jwt.decode(token)
-  if (!decoded || typeof decoded !== 'object' || !decoded.id) return null
-  return decoded.id
+  try {
+    const decoded = getUserFromToken(token)
+    return decoded.id
+  } catch {
+    return null
+  }
 }
 
 export async function PATCH(req: NextRequest, context: { params: { id: string } }) {

--- a/src/app/api/cartes/route.ts
+++ b/src/app/api/cartes/route.ts
@@ -2,15 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/lib/auth'
 
 async function getUserIdFromRequest() {
   const cookieStore = await cookies()
   const token = cookieStore.get('payload-token')?.value
   if (!token) return null
-  const decoded = jwt.decode(token)
-  if (!decoded || typeof decoded !== 'object' || !decoded.id) return null
-  return decoded.id
+  try {
+    const decoded = getUserFromToken(token)
+    return decoded.id
+  } catch {
+    return null
+  }
 }
 
 export async function GET(req: NextRequest) {

--- a/src/app/api/custom-cat/route.ts
+++ b/src/app/api/custom-cat/route.ts
@@ -2,15 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/lib/auth'
 
 async function getUserIdFromRequest() {
   const cookieStore = await cookies()
   const token = cookieStore.get('payload-token')?.value
   if (!token) return null
-  const decoded = jwt.decode(token)
-  if (!decoded || typeof decoded !== 'object' || !decoded.id) return null
-  return decoded.id
+  try {
+    const decoded = getUserFromToken(token)
+    return decoded.id
+  } catch {
+    return null
+  }
 }
 
 export async function GET(req: NextRequest) {

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import config from '@/payload.config'
 import { cookies } from 'next/headers'
-import jwt from 'jsonwebtoken'
+import { getUserFromToken } from '@/lib/auth'
 
 export async function GET(req: NextRequest) {
   const cookieStore = await cookies()
@@ -13,10 +13,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const decoded = jwt.decode(token)
-    if (!decoded || typeof decoded !== 'object' || !decoded.id) {
-      return NextResponse.json({ user: null }, { status: 401 })
-    }
+    const decoded = getUserFromToken(token)
 
     const payload = await getPayload({ config })
     const { docs } = await payload.find({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,13 @@
+import { verify, JwtPayload } from 'jsonwebtoken'
+
+export function getUserFromToken(token: string): JwtPayload & { id: string } {
+  const secret = process.env.PAYLOAD_SECRET
+  if (!secret) throw new Error('Missing PAYLOAD_SECRET')
+
+  const decoded = verify(token, secret)
+  if (typeof decoded !== 'object' || decoded === null || !('id' in decoded)) {
+    throw new Error('Invalid token payload')
+  }
+
+  return decoded as JwtPayload & { id: string }
+}


### PR DESCRIPTION
## Summary
- add `getUserFromToken` helper that verifies JWT tokens
- use helper in auth protected API routes
- verify token in dashboard layout

## Testing
- `pnpm lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d30b863fc8326943afa426dfb0355